### PR TITLE
Show original code from source file when the code has pipeline forms

### DIFF
--- a/lib/dbg.ex
+++ b/lib/dbg.ex
@@ -6,11 +6,11 @@ defmodule Dbg do
   @doc """
   `Dbg.inspect/2` prints the first argument like regular IO.inspect/1,
   but including filename and line of code,
-  where it was called, and a representation of the expression 
-  passed as the first argument, provides colored output to simplify it detecting 
-  and ability to include values of variables, used it this expression, in this output. 
+  where it was called, and a representation of the expression
+  passed as the first argument, provides colored output to simplify it detecting
+  and ability to include values of variables, used it this expression, in this output.
 
-  It's worth noting that `Dbg.inspect/2` prints its output to :stderr stream. 
+  It's worth noting that `Dbg.inspect/2` prints its output to :stderr stream.
   And also doesn't add any performance penalty in `production` enviroment,
   b/c when `Mix.env == :prod` it doesn't change an original AST at all.
 
@@ -24,7 +24,7 @@ defmodule Dbg do
 
       > x = 7
       > x |> Dbg.inspect()
-      
+
       ./dbg.ex:16
       x # => 7
 
@@ -37,13 +37,14 @@ defmodule Dbg do
   See more examples in tests.
   """
   defmacro inspect(ast, opts \\ [show_vars: false]) do
-    inspect(Mix.env(), ast, opts)
+    original_code = try_get_original_code(__CALLER__, ast)
+    inspect(Mix.env(), ast, [{:original_code, original_code} | opts])
   end
 
   defp inspect(:prod, ast, _opts), do: ast
 
   defp inspect(_env, ast, opts) do
-    value_representation = generate_value_representation(ast)
+    value_representation = opts[:original_code] || generate_value_representation(ast)
     vars = get_vars(ast, opts)
 
     quote do
@@ -59,7 +60,6 @@ defmodule Dbg do
       unquote(vars) |> Dbg.print_vars()
 
       IO.puts(:stderr, [
-        "  ",
         unquote(value_representation),
         " #=> ",
         Kernel.inspect(result),
@@ -82,20 +82,25 @@ defmodule Dbg do
   end
 
   defp generate_value_representation(ast) do
-    ast
-    |> Macro.to_string()
-    |> Code.format_string!(line_length: 60)
-    |> Enum.join()
-    |> String.replace("\n", "\n  ")
+    re =
+      ast
+      |> Macro.to_string()
+      |> Code.format_string!(line_length: 60)
+      |> Enum.join()
+      |> String.replace("\n", "\n  ")
+
+    "  " <> re
   end
 
-  defp get_vars(ast, show_vars: true) do
-    ast
-    |> find_vars([])
-    |> Enum.map(&{elem(&1, 0), &1})
+  defp get_vars(ast, opts) do
+    if opts[:show_vars] do
+      ast
+      |> find_vars([])
+      |> Enum.map(&{elem(&1, 0), &1})
+    else
+      []
+    end
   end
-
-  defp get_vars(_, _), do: []
 
   defp find_vars({_, _, [inner_ast]}, vars) do
     find_vars(inner_ast, vars)
@@ -125,4 +130,61 @@ defmodule Dbg do
   defp only_vars([{label, var_ast}]) when is_atom(label), do: only_vars(var_ast)
   defp only_vars({label, var_ast}) when is_atom(label), do: only_vars(var_ast)
   defp only_vars(_), do: false
+
+  # return code from file when the code has pipeline forms
+  defp try_get_original_code(caller, ast) do
+    with true <- caller.file != "iex",
+         # pipeline code should has a least 2 lines
+         {line_min, line_max}
+         when line_min != nil and line_max != nil and line_min < line_max <-
+           get_code_line_range(ast),
+         # pipeline code should be above the call line
+         true <- line_max < caller.line,
+         # source code should exists
+         File.exists?(caller.file),
+         {:ok, code} = File.read(caller.file),
+         lines <- String.split(code, "\n"),
+         call_line when call_line != nil <- Enum.at(lines, caller.line - 1),
+         call_line <- String.trim(call_line),
+         # call line should starts with "|>"
+         true <- String.starts_with?(call_line, "|>") do
+      lines
+      |> Enum.drop(line_min - 1)
+      |> Enum.take(line_max - line_min + 1)
+      |> adjust_indent()
+      |> Enum.join("\n")
+    else
+      _ -> nil
+    end
+  end
+
+  defp adjust_indent(lines) do
+    min_indent =
+      lines
+      |> Enum.map(fn line ->
+        len1 = byte_size(line)
+        len2 = String.trim_leading(line, " ") |> byte_size()
+        len1 - len2
+      end)
+      |> Enum.min(fn -> 0 end)
+
+    lines
+    |> Enum.map(&String.slice(&1, min_indent..-1))
+    |> Enum.map(&"  #{&1}")
+  end
+
+  defp get_code_line_range(ast) do
+    {_, range} =
+      Macro.postwalk(ast, {nil, nil}, fn
+        {_, [{:line, line} | _], _} = ast, {line_min, line_max} ->
+          line_min = min(line, line_min || line)
+          line_max = max(line, line_max || line)
+          {ast, {line_min, line_max}}
+
+        ast, acc ->
+          {ast, acc}
+      end)
+
+    range
+  end
 end

--- a/test/dbg_test.exs
+++ b/test/dbg_test.exs
@@ -153,7 +153,7 @@ defmodule DbgTest do
     end
 
     assert dbg_inspect(fun) == [
-             "./test/dbg_test.exs:146",
+             "./test/dbg_test.exs:152",
              "  x = 5",
              "  y = 7",
              "  x |> max(y) #=> 7"

--- a/test/dbg_test.exs
+++ b/test/dbg_test.exs
@@ -48,7 +48,9 @@ defmodule DbgTest do
 
     assert dbg_inspect(fun) == [
              "./test/dbg_test.exs:46",
-             "  String.to_integer(to_string(x + 5)) #=> 12"
+             "  (x + 5)",
+             "  |> to_string",
+             "  |> String.to_integer() #=> 12"
            ]
   end
 
@@ -63,8 +65,10 @@ defmodule DbgTest do
     end
 
     assert dbg_inspect(fun) == [
-             "./test/dbg_test.exs:62",
-             "  Enum.into(Enum.map(list, &{&1, to_string(&1 * &1)}), %{}) #=> %{1 => \"1\", 2 => \"4\", 3 => \"9\"}"
+             "./test/dbg_test.exs:64",
+             "  list",
+             "  |> Enum.map(&{&1, to_string(&1 * &1)})",
+             "  |> Enum.into(%{}) #=> %{1 => \"1\", 2 => \"4\", 3 => \"9\"}"
            ]
   end
 
@@ -79,8 +83,9 @@ defmodule DbgTest do
     end
 
     assert dbg_inspect(fun) == [
-             "./test/dbg_test.exs:77",
-             "  to_string(x + 5) #=> \"12\""
+             "./test/dbg_test.exs:81",
+             "  (x + 5)",
+             "  |> to_string #=> \"12\""
            ]
   end
 
@@ -92,7 +97,7 @@ defmodule DbgTest do
     end
 
     assert dbg_inspect(fun) == [
-             "./test/dbg_test.exs:91",
+             "./test/dbg_test.exs:96",
              "  x = 7",
              "  y = 5",
              "  x + y #=> 12"
@@ -110,9 +115,11 @@ defmodule DbgTest do
     end
 
     assert dbg_inspect(fun) == [
-             "./test/dbg_test.exs:109",
+             "./test/dbg_test.exs:114",
              "  list = [1, 2, 3]",
-             "  Enum.into(Enum.map(list, &{&1, to_string(&1 * &1)}), %{}) #=> %{1 => \"1\", 2 => \"4\", 3 => \"9\"}"
+             "  list",
+             "  |> Enum.map(&{&1, to_string(&1 * &1)})",
+             "  |> Enum.into(%{}) #=> %{1 => \"1\", 2 => \"4\", 3 => \"9\"}"
            ]
   end
 
@@ -129,14 +136,13 @@ defmodule DbgTest do
     end
 
     assert dbg_inspect(fun) == [
-             "./test/dbg_test.exs:128",
+             "./test/dbg_test.exs:135",
              "  list = [1, 2, 3]",
              "  zero = 0",
-             "  Map.put(",
-             "    Enum.into(Enum.map(list, &{&1, to_string(&1 * &1)}), %{}),",
-             "    zero,",
-             "    to_string(zero)",
-             "  ) #=> %{0 => \"0\", 1 => \"1\", 2 => \"4\", 3 => \"9\"}"
+             "  list",
+             "  |> Enum.map(&{&1, to_string(&1 * &1)})",
+             "  |> Enum.into(%{})",
+             "  |> Map.put(zero, to_string(zero)) #=> %{0 => \"0\", 1 => \"1\", 2 => \"4\", 3 => \"9\"}"
            ]
   end
 end


### PR DESCRIPTION
Printing the original code will be better.

```
./test/dbg_test.exs:135
  list = [1, 2, 3]
  zero = 0
  list
  |> Enum.map(&{&1, to_string(&1 * &1)})
  |> Enum.into(%{})
  |> Map.put(zero, to_string(zero)) #=> %{0 => "0", 1 => "1", 2 => "4", 3 => "9"}
```